### PR TITLE
cs: translate a few registration-related strings

### DIFF
--- a/cs.lproj/Localizable.strings
+++ b/cs.lproj/Localizable.strings
@@ -614,8 +614,8 @@
 "Hong Kong, China" = "Hong Kong, China";
 /* quicksy country */
 "Hungary" = "Hungary";
-"I already have an account:" = "I already have an account:";
-"I need an account:" = "I need an account:";
+"I already have an account:" = "Již mám účet:";
+"I need an account:" = "Potřebuji účet:";
 /* quicksy country */
 "Iceland" = "Iceland";
 "If Monal can't show notifications, you will not see alerts when a message arrives. This happens if you tapped 'Decline' when Monal first asked permission. Fix it by going to iOS Settings -> Monal -> Notifications and select 'Allow Notifications'." = "Pokud Monal nemůže zobrazovat oznámení, neuvidíte upozornění, když přijde nová zpráva. K tomu dochází, pokud jste klepli na \"Odmítnout\" při první žádosti Monalu o udělení oprávnění. Oznámení můžete povolit v Nastavení (iOS) -> Monal -> Oznámení  a aktivujete 'Povolit oznámení'.";
@@ -715,7 +715,7 @@
 "Libya" = "Libya";
 /* quicksy country */
 "Liechtenstein" = "Liechtenstein";
-"Like email, you can register your account on many sites and talk to anyone. You can use this page to register an account with a selected or provided XMPP server. You also have to choose a username and a password." = "Like email, you can register your account on many sites and talk to anyone. You can use this page to register an account with a selected or provided XMPP server. You also have to choose a username and a password.";
+"Like email, you can register your account on many sites and talk to anyone. You can use this page to register an account with a selected or provided XMPP server. You also have to choose a username and a password." = "Stejně jako u emailu můžete k vytvoření účtu použít různé poskytovatele a přesto budete stále moci komunikovat se všemi. Na této stránce si můžete vytvořit účet na vybraném nebo zadaném XMPP serveru. Rovněž si musíte zvolit uživatelské jméno a heslo.";
 /* quicksy country */
 "Lithuania" = "Lithuania";
 "Load over Cellular" = "Load over Cellular";
@@ -729,10 +729,10 @@
 "Loading omemo bundles: %@ / %@" = "Nahrávám informace OMEMO: %1$@ / %2$@";
 "Loading OMEMO keys" = "Loading OMEMO keys";
 "Location Access Needed" = "Vyžadován přístup k poloze";
-"Log in to your existing account or register a new account. If required you will find more advanced options in Monal settings." = "Log in to your existing account or register a new account. If required you will find more advanced options in Monal settings.";
+"Log in to your existing account or register a new account. If required you will find more advanced options in Monal settings." = "Přihlašte se svým účtem nebo si vytvořte nový. Pokročilé možnosti v případě potřeby najdete v nastavení aplikace Monal.";
 "Logfiles" = "Logfiles";
 "Logging in" = "Přihlašuji";
-"Login" = "Login";
+"Login" = "Přihlásit";
 "Login error, account disabled: %@" = "Login error, account disabled: %@";
 "Logs" = "Logs";
 /* quicksy country */
@@ -922,7 +922,7 @@
    placeholder when migrating account */
 "Password" = "Heslo";
 /* placeholder when creating account */
-"Password (repeated)" = "Password (repeated)";
+"Password (repeated)" = "Heslo (znovu)";
 "Password cannot be empty" = "Heslo nesmí být prázdné";
 "Password missing" = "Chybějící heslo";
 "Passwords don't match!" = "Passwords don't match!";
@@ -997,8 +997,8 @@
 "Recording audio" = "Nahrávám audio";
 "Red x-mark shield:" = "Red x-mark shield:";
 "Refreshing..." = "Aktualizace...";
-"Register a new account" = "Register a new account";
-"Register with %@" = "Register with %@";
+"Register a new account" = "Vytvořit nový účet";
+"Register with %@" = "Vytvořit účet na %@";
 "Registering account..." = "Registruji účet...";
 "Registration Error" = "Registration Error";
 "Remove %@ from contacts?" = "Odstranit %@ z kontaktů?";
@@ -1175,7 +1175,7 @@
 "Temporarily unavailable. Try again later." = "Temporarily unavailable. Try again later.";
 "Temporary failure to enter Group/Channel: %@" = "Temporary failure to enter Group/Channel: %@";
 "Terms of %@" = "Terms of %@";
-"Terms of use for %@" = "Terms of use for %@";
+"Terms of use for %@" = "Podmínky použití %@";
 /* quicksy country */
 "Thailand" = "Thailand";
 "The account has been deleted" = "Účet byl smazán";
@@ -1199,7 +1199,7 @@
 /* QR-Code-Scanner: account scan wrong menu */
 "The qrcode contains login credentials for an acount. Go to settings -> new account and rescan the qrcode" = "The qrcode contains login credentials for an acount. Go to settings -> new account and rescan the qrcode";
 "The resource '%@' has the following capabilities:" = "The resource '%@' has the following capabilities:";
-"The selectable XMPP servers are public servers which are not affiliated to Monal. This registration page is provided for convenience only." = "The selectable XMPP servers are public servers which are not affiliated to Monal. This registration page is provided for convenience only.";
+"The selectable XMPP servers are public servers which are not affiliated to Monal. This registration page is provided for convenience only." = "Nabízené XMPP servery jsou veřejné a nemají žádné vazby na Monal. Tato stránka existuje pouze pro usnadnění registrace.";
 "The server does not support blocking (XEP-0191)." = "The server does not support blocking (XEP-0191).";
 "The server tried to bind you to jid '%@', but you configured '%@', disabling account!" = "The server tried to bind you to jid '%1$@', but you configured '%2$@', disabling account!";
 "The UDP logger allows you to livestream the log to the configured IP." = "The UDP logger allows you to livestream the log to the configured IP.";


### PR DESCRIPTION
The main motivation was to use one of the previously not translated
strings in the Czech translation of the DI.DAY flyer.
